### PR TITLE
Improvements to containerization (local artifact support, robust image construction)

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+harvest-server.cfg

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ FROM openjdk:11-slim
 # from the GitHub releases. However, you can override this, such as with a
 # `file:` URL, to a locally built release if you're testing out changes.
 
-ARG regisrty_harvest_service_url=https://github.com/NASA-PDS/registry-harvest-service/releases/download/v1.2.0/registry-harvest-service-1.2.0-bin.tar.gz
+ARG registry_harvest_service_url=https://github.com/NASA-PDS/registry-harvest-service/releases/download/v1.2.0/registry-harvest-service-1.2.0-bin.tar.gz
 
 
 # Image Layers
@@ -60,7 +60,7 @@ ARG regisrty_harvest_service_url=https://github.com/NASA-PDS/registry-harvest-se
 RUN : &&\
     apt-get update --quiet --yes &&\
     apt-get install --quiet --yes curl &&\
-    curl --verbose --location --fail "$regisrty_harvest_service_url" >/tmp/registry-harvest-service-bin.tar.gz &&\
+    curl --verbose --location --fail "$registry_harvest_service_url" >/tmp/registry-harvest-service-bin.tar.gz &&\
     : Sanity check to make sure we got some bytes &&\
     [ -s /tmp/registry-harvest-service-bin.tar.gz ] || exit 1 &&\
     mkdir /opt/registry-harvest-service &&\

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
-# Copyright 2022, California Institute of Technology ("Caltech").
+# Dockerfile for Registry Harvest Service
+# =======================================
+#
+# Copyright © 2023, California Institute of Technology ("Caltech").
 # U.S. Government sponsorship acknowledged.
 #
 # All rights reserved.
@@ -27,25 +30,67 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+#
+# Basis
+# -----
+#
+# This is Java, so we'll start off with a nice slim version of OpenJDK, 11.
 
 FROM openjdk:11-slim
 
-# Set the following argument with a compatible Registry Harvest Service version
-ARG registry_harvest_service_version=1.2.0-SNAPSHOT
 
-ENV REGISTRY_HARVEST_SERVICE_BIN_PATH=https://github.com/NASA-PDS/registry-harvest-service/releases/download/v${registry_harvest_service_version}/registry-harvest-service-${registry_harvest_service_version}-bin.tar.gz
+# Build Arguments
+# ---------------
+#
+# The sole build argument is for the URL to the Registry Harvest Service
+# binary distribution. By default, that'll be version 1.2.0 taken
+# from the GitHub releases. However, you can override this, such as with a
+# `file:` URL, to a locally built release if you're testing out changes.
 
-# Install Registry Harvest Service
-ADD $REGISTRY_HARVEST_SERVICE_BIN_PATH /tmp/registry-harvest-service-bin.tar.gz
-RUN  apt-get update -y &&\
-     apt-get install curl -y &&\
-     mkdir /opt/registry-harvest-service &&\
-     tar xzf /tmp/registry-harvest-service-bin.tar.gz  -C /opt/registry-harvest-service --strip-components 1 &&\
-     rm -f /tmp/registry-harvest-service-bin.tar.gz &&\
-     apt-get autoclean --quiet --yes &&\
-     rm -rf /var/lib/apt/lists/*
+ARG regisrty_harvest_service_url=https://github.com/NASA-PDS/registry-harvest-service/releases/download/v1.2.0/registry-harvest-service-1.2.0-bin.tar.gz
+
+
+# Image Layers
+# ------------
+#
+# What we actually put into the image. We install and run `curl` instead of
+# using Docker's `ADD` because the latter hides errors. For example, if you
+# `ADD` a URL that's a 404, it will bizarrely add the current directory!
+
+RUN : &&\
+    apt-get update --quiet --yes &&\
+    apt-get install --quiet --yes curl &&\
+    curl --verbose --location --fail "$regisrty_harvest_service_url" >/tmp/registry-harvest-service-bin.tar.gz &&\
+    : Sanity check to make sure we got some bytes &&\
+    [ -s /tmp/registry-harvest-service-bin.tar.gz ] || exit 1 &&\
+    mkdir /opt/registry-harvest-service &&\
+    tar --extract --gzip --file /tmp/registry-harvest-service-bin.tar.gz --directory /opt/registry-harvest-service --strip-components 1 &&\
+    rm /tmp/registry-harvest-service-bin.tar.gz &&\
+    apt-get autoclean --quiet --yes &&\
+    rm --recursive --force /var/lib/apt/lists/*
+
+
+# Environment
+# -----------
+#
+# Make sure we can execute commands out of the new bin dir.
+
 ENV PATH="$PATH:/opt/registry-harvest-service/bin"
 
+
 # Entry point
+# -----------
+#
+# Where the magic happens.
+
 COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["bash", "/usr/local/bin/entrypoint.sh"]
+
+
+# Metadata
+# --------
+#
+# Does anyone actually use this?
+
+LABEL "org.label-schema.name"="PDS Registry Harvest Service"
+LABEL "org.label-schema.description"="Supports the capturing and indexing of product metadata into the PDS Registry system"

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,50 +1,44 @@
 # 🪐 Docker Image and Container for Registry Harvest Service
 
-## 🏃 Steps to build the docker image of the Registry Harvest Service
+This directory contains Docker-related information for making and running a containerized version of the Registry Harvest Service.
 
-#### 1. Update (if required) the following Registry Harvest Service version in the `Dockerfile` with a compatible versions.
 
-| Variable                        | Description |
-| ------------------------------- | ------------|
-| registry_harvest_service_version | The version of the Registry Harvest Service release to be included in the docker image|
+## 🧱 Building the Image
 
-```    
-# Set the following argument with a compatible Registry Harvest Service version
-ARG registry_harvest_service_version=1.0.0-SNAPSHOT
+There's one build argument (normally specified with `--build-arg`) that you can specify at image construction time: `registry_harvest_service_url`. This should be set to the URL of the _binary distribution_ (in a gzip'd tar file) of the Registry Harvest Service that will be installed into the image.
+
+Here are some example uses of the build argument:
+
+1. `--build-arg "registry_harvest_service_url=https://github.com/NASA-PDS/registry-harvest-service/releases/download/v1.2.0/registry-harvest-service-1.2.0-bin.tar.gz"` — uses version 1.2.0 from GitHub
+2. `--build-arg "registry_harvest_service_url=file:/Users/tloubrieu/PDS/registry-harvest-service/target/registry-harvest-service-1.3.0-SNAPSHOT-bin.tar.gz"` — uses a locally built version of 1.3.0-SNAPSHOT
+
+As of this writing, if no `--build-arg` for `registry_harvest_service_url` is given then №1 above is the default.
+
+Then, head over to the `registry-harvest-service/docker` directory and run:
+
+    docker image build BUILD-ARG --tag nasapds/registry-harvest-service .
+
+to build the image. Replace `BUILD_ARG` as needed.
+
+As an optional step, push the newly created image to a container hub. For example, to push it to Docker Hub using the credentials for https://hub.docker.com/u/nasapds:
+```console
+$ docker login
+$ docker image push nasapds/registry-harvest-service
 ```
 
-#### 2. Open a terminal and change the current working directory to `registry-harvest-service/docker`.
-
-#### 3. Build the docker image as follows.
-
-```
-docker image build --tag nasapds/registry-harvest-service .
-```
-
-#### 4. As an optional step, push the docker image to a container image library.
-
-For example, follow the below steps to push the newly built image to the Docker Hub.
-
-* Execute the following command to log into the Docker Hub with a username and password (use the username and password of https://hub.docker.com/u/nasapds).
-```
-docker login
-```
-* Push the docker image to the Docker Hub.
-```
-docker image push nasapds/registry-harvest-service
-```
-* Visit the Docker Hub (https://hub.docker.com/u/nasapds) and make sure that the `nasapds/registry-harvest-service` image is available, so that it can be reused by other users without building it.
+Visit the Docker Hub (https://hub.docker.com/u/nasapds) and make sure that the `nasapds/registry-harvest-service` image is available, so that it can be reused by other users without building it.
 
 
-## 🏃 Steps to run a docker container of the Registry Harvest Service
+## 🏃 Running a Docker Container of the Registry Harvest Service
 
-#### 1. Update the Registry Harvest Service configuration file.
+To run the containerized Registry Harvest Service, do the following:
 
-* Get a copy of the `harvest-server.cfg` file from https://github.com/NASA-PDS/registry-harvest-service/blob/main/src/main/resources/conf/harvest-server.cfg and
-keep it in a local file location such as `/tmp/cfg/harvest-server.cfg`.
-* Update the properties such as `rmq.host`, `rmq.user`, `rmq.password` and `es.url` to match with your deployment environment.
+1. Update the Registry Harvest Service configuration file.
 
-#### 2. Update the following environment variables in the `run.sh`.
+- Get a copy of the `harvest-server.cfg` file from https://github.com/NASA-PDS/registry-harvest-service/blob/main/src/main/resources/conf/harvest-server.cfg and keep it in a local file location such as `/tmp/cfg/harvest-server.cfg`. You may want to run it through `json_pp` to make it more readable.
+- Update the properties such as `rmq.host`, `rmq.user`, `rmq.password` and `es.url` to match with your deployment environment.
+
+2. Update the following environment variables in the `run.sh`.
 
 | Variable                   | Description |
 | -------------------------- | ----------- |
@@ -70,25 +64,18 @@ HARVEST_SERVER_CONFIG_FILE=/tmp/cfg/harvest-server.cfg
 HARVEST_DATA_DIR=/tmp/registry-harvest-data
 ```
 
-Note:
+**👉 Note:** Make sure to have the same `HARVEST_DATA_DIR` value set in the environment variables of the Registry Harvest Service, Registry Crawler Service and Registry Harvest CLI. Also, this `HARVEST_DATA_DIR` location should be accessible from the docker containers of the Registry Harvest Service, Registry Crawler Service and Registry Harvest CLI.
 
-Make sure to have the same `HARVEST_DATA_DIR` value set in the environment variables of the Registry Harvest Service,
-Registry Crawler Service and Registry Harvest CLI. Also, this `HARVEST_DATA_DIR` location should be accessible from the
-docker containers of the Registry Harvest Service, Registry Crawler Service and Registry Harvest CLI.
+3. Open a terminal and change the current working directory to `registry-harvest-service/docker`.
 
-
-#### 3. Open a terminal and change the current working directory to `registry-harvest-service/docker`.
-
-#### 4. If executing for the first time, change the execution permissions of `run.sh` file as follows.
-
-```
-chmod u+x run.sh
+4. If executing for the first time, change the execution permissions of `run.sh` file as follows.
+```console
+$ chmod u+x run.sh
 ```
 
-#### 5. Execute the `run.sh` as follows.
-
+5. Execute the `run.sh` as follows.
+``` console
+$ ./run.sh
 ```
-./run.sh
-```
 
-Above steps will run a docker container of the Registry Harvest Service.
+Above steps will run a Docker container of the Registry Harvest Service.


### PR DESCRIPTION
## 🗒️ Summary

-   Make it so you specify a URL to a distribution instead of a version;
    -   Enables you to use locally-built artifacts with `file:` URLs and eases development
-   Make image construction more robust
    -   The `ADD` statement hides error conditions and leads to baffling/broken images
    -   `curl` is better but needs to be told to follow redirects and fail on 404s
    -   Additional sanity checks

## ⚙️ Test Data and/or Report
```console
$ docker image build --no-cache --progress plain --tag nasapds/registry-harvest-service .
#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 3.82kB done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/openjdk:11-slim
#3 DONE 0.0s

#4 [1/3] FROM docker.io/library/openjdk:11-slim
#4 CACHED

#5 [internal] load build context
#5 transferring context: 35B done
#5 DONE 0.0s

#6 [2/3] RUN : &&    apt-get update --quiet --yes &&    apt-get install --quiet --yes curl &&    curl --verbose --location --fail "https://github.com/NASA-PDS/registry-harvest-service/releases/download/v1.2.0/registry-harvest-service-1.2.0-bin.tar.gz" >/tmp/registry-harvest-service-bin.tar.gz &&    : Sanity check to make sure we got some bytes &&    [ -s /tmp/registry-harvest-service-bin.tar.gz ] || exit 1 &&    mkdir /opt/registry-harvest-service &&    tar --extract --gzip --file /tmp/registry-harvest-service-bin.tar.gz --directory /opt/registry-harvest-service --strip-components 1 &&    rm /tmp/registry-harvest-service-bin.tar.gz &&    apt-get autoclean --quiet --yes &&    rm --recursive --force /var/lib/apt/lists/*
#6 0.156 Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
#6 0.192 Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [48.4 kB]
#6 0.212 Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB]
#6 0.288 Get:4 http://deb.debian.org/debian bullseye/main arm64 Packages [8071 kB]
#6 0.482 Get:5 http://deb.debian.org/debian-security bullseye-security/main arm64 Packages [242 kB]
#6 0.489 Get:6 http://deb.debian.org/debian bullseye-updates/main arm64 Packages [14.9 kB]
#6 1.118 Fetched 8535 kB in 1s (8614 kB/s)
#6 1.118 Reading package lists...
#6 1.397 Reading package lists...
#6 1.672 Building dependency tree...
#6 1.733 Reading state information...
#6 1.801 The following additional packages will be installed:
#6 1.801   libbrotli1 libcurl4 libldap-2.4-2 libldap-common libnghttp2-14 libpsl5
#6 1.801   librtmp1 libsasl2-2 libsasl2-modules libsasl2-modules-db libssh2-1
#6 1.801   publicsuffix
#6 1.801 Suggested packages:
#6 1.801   libsasl2-modules-gssapi-mit | libsasl2-modules-gssapi-heimdal
#6 1.801   libsasl2-modules-ldap libsasl2-modules-otp libsasl2-modules-sql
#6 1.869 The following NEW packages will be installed:
#6 1.869   curl libbrotli1 libcurl4 libldap-2.4-2 libldap-common libnghttp2-14 libpsl5
#6 1.869   librtmp1 libsasl2-2 libsasl2-modules libsasl2-modules-db libssh2-1
#6 1.869   publicsuffix
#6 1.909 0 upgraded, 13 newly installed, 0 to remove and 24 not upgraded.
#6 1.909 Need to get 1918 kB of archives.
#6 1.909 After this operation, 4231 kB of additional disk space will be used.
#6 1.909 Get:1 http://deb.debian.org/debian bullseye/main arm64 libbrotli1 arm64 1.0.9-2+b2 [267 kB]
#6 1.960 Get:2 http://deb.debian.org/debian bullseye/main arm64 libsasl2-modules-db arm64 2.1.27+dfsg-2.1+deb11u1 [69.4 kB]
#6 1.964 Get:3 http://deb.debian.org/debian bullseye/main arm64 libsasl2-2 arm64 2.1.27+dfsg-2.1+deb11u1 [105 kB]
#6 1.966 Get:4 http://deb.debian.org/debian bullseye/main arm64 libldap-2.4-2 arm64 2.4.57+dfsg-3+deb11u1 [222 kB]
#6 1.979 Get:5 http://deb.debian.org/debian bullseye/main arm64 libnghttp2-14 arm64 1.43.0-1 [73.8 kB]
#6 1.981 Get:6 http://deb.debian.org/debian bullseye/main arm64 libpsl5 arm64 0.21.0-1.2 [57.1 kB]
#6 1.982 Get:7 http://deb.debian.org/debian bullseye/main arm64 librtmp1 arm64 2.4+20151223.gitfa8646d.1-2+b2 [59.4 kB]
#6 1.984 Get:8 http://deb.debian.org/debian bullseye/main arm64 libssh2-1 arm64 1.9.0-2 [150 kB]
#6 2.002 Get:9 http://deb.debian.org/debian bullseye/main arm64 libcurl4 arm64 7.74.0-1.3+deb11u7 [325 kB]
#6 2.011 Get:10 http://deb.debian.org/debian bullseye/main arm64 curl arm64 7.74.0-1.3+deb11u7 [265 kB]
#6 2.015 Get:11 http://deb.debian.org/debian bullseye/main arm64 libldap-common all 2.4.57+dfsg-3+deb11u1 [95.8 kB]
#6 2.016 Get:12 http://deb.debian.org/debian bullseye/main arm64 libsasl2-modules arm64 2.1.27+dfsg-2.1+deb11u1 [101 kB]
#6 2.018 Get:13 http://deb.debian.org/debian bullseye/main arm64 publicsuffix all 20220811.1734-0+deb11u1 [127 kB]
#6 2.088 debconf: delaying package configuration, since apt-utils is not installed
#6 2.107 Fetched 1918 kB in 0s (12.9 MB/s)
#6 2.122 Selecting previously unselected package libbrotli1:arm64.
#6 2.122 (Reading database ... 
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 7063 files and directories currently installed.)
#6 2.127 Preparing to unpack .../00-libbrotli1_1.0.9-2+b2_arm64.deb ...
#6 2.129 Unpacking libbrotli1:arm64 (1.0.9-2+b2) ...
#6 2.162 Selecting previously unselected package libsasl2-modules-db:arm64.
#6 2.162 Preparing to unpack .../01-libsasl2-modules-db_2.1.27+dfsg-2.1+deb11u1_arm64.deb ...
#6 2.164 Unpacking libsasl2-modules-db:arm64 (2.1.27+dfsg-2.1+deb11u1) ...
#6 2.183 Selecting previously unselected package libsasl2-2:arm64.
#6 2.184 Preparing to unpack .../02-libsasl2-2_2.1.27+dfsg-2.1+deb11u1_arm64.deb ...
#6 2.187 Unpacking libsasl2-2:arm64 (2.1.27+dfsg-2.1+deb11u1) ...
#6 2.210 Selecting previously unselected package libldap-2.4-2:arm64.
#6 2.211 Preparing to unpack .../03-libldap-2.4-2_2.4.57+dfsg-3+deb11u1_arm64.deb ...
#6 2.212 Unpacking libldap-2.4-2:arm64 (2.4.57+dfsg-3+deb11u1) ...
#6 2.242 Selecting previously unselected package libnghttp2-14:arm64.
#6 2.243 Preparing to unpack .../04-libnghttp2-14_1.43.0-1_arm64.deb ...
#6 2.246 Unpacking libnghttp2-14:arm64 (1.43.0-1) ...
#6 2.267 Selecting previously unselected package libpsl5:arm64.
#6 2.268 Preparing to unpack .../05-libpsl5_0.21.0-1.2_arm64.deb ...
#6 2.270 Unpacking libpsl5:arm64 (0.21.0-1.2) ...
#6 2.289 Selecting previously unselected package librtmp1:arm64.
#6 2.290 Preparing to unpack .../06-librtmp1_2.4+20151223.gitfa8646d.1-2+b2_arm64.deb ...
#6 2.292 Unpacking librtmp1:arm64 (2.4+20151223.gitfa8646d.1-2+b2) ...
#6 2.311 Selecting previously unselected package libssh2-1:arm64.
#6 2.312 Preparing to unpack .../07-libssh2-1_1.9.0-2_arm64.deb ...
#6 2.313 Unpacking libssh2-1:arm64 (1.9.0-2) ...
#6 2.338 Selecting previously unselected package libcurl4:arm64.
#6 2.339 Preparing to unpack .../08-libcurl4_7.74.0-1.3+deb11u7_arm64.deb ...
#6 2.340 Unpacking libcurl4:arm64 (7.74.0-1.3+deb11u7) ...
#6 2.371 Selecting previously unselected package curl.
#6 2.372 Preparing to unpack .../09-curl_7.74.0-1.3+deb11u7_arm64.deb ...
#6 2.373 Unpacking curl (7.74.0-1.3+deb11u7) ...
#6 2.401 Selecting previously unselected package libldap-common.
#6 2.402 Preparing to unpack .../10-libldap-common_2.4.57+dfsg-3+deb11u1_all.deb ...
#6 2.404 Unpacking libldap-common (2.4.57+dfsg-3+deb11u1) ...
#6 2.425 Selecting previously unselected package libsasl2-modules:arm64.
#6 2.426 Preparing to unpack .../11-libsasl2-modules_2.1.27+dfsg-2.1+deb11u1_arm64.deb ...
#6 2.427 Unpacking libsasl2-modules:arm64 (2.1.27+dfsg-2.1+deb11u1) ...
#6 2.447 Selecting previously unselected package publicsuffix.
#6 2.448 Preparing to unpack .../12-publicsuffix_20220811.1734-0+deb11u1_all.deb ...
#6 2.451 Unpacking publicsuffix (20220811.1734-0+deb11u1) ...
#6 2.475 Setting up libpsl5:arm64 (0.21.0-1.2) ...
#6 2.479 Setting up libbrotli1:arm64 (1.0.9-2+b2) ...
#6 2.484 Setting up libsasl2-modules:arm64 (2.1.27+dfsg-2.1+deb11u1) ...
#6 2.490 Setting up libnghttp2-14:arm64 (1.43.0-1) ...
#6 2.495 Setting up libldap-common (2.4.57+dfsg-3+deb11u1) ...
#6 2.501 Setting up libsasl2-modules-db:arm64 (2.1.27+dfsg-2.1+deb11u1) ...
#6 2.504 Setting up librtmp1:arm64 (2.4+20151223.gitfa8646d.1-2+b2) ...
#6 2.507 Setting up libsasl2-2:arm64 (2.1.27+dfsg-2.1+deb11u1) ...
#6 2.510 Setting up libssh2-1:arm64 (1.9.0-2) ...
#6 2.513 Setting up publicsuffix (20220811.1734-0+deb11u1) ...
#6 2.516 Setting up libldap-2.4-2:arm64 (2.4.57+dfsg-3+deb11u1) ...
#6 2.519 Setting up libcurl4:arm64 (7.74.0-1.3+deb11u7) ...
#6 2.522 Setting up curl (7.74.0-1.3+deb11u7) ...
#6 2.525 Processing triggers for libc-bin (2.31-13+deb11u3) ...
#6 2.559   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#6 2.559                                  Dload  Upload   Total   Spent    Left  Speed
#6 2.559 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 140.82.114.3:443...
#6 2.603 * Connected to github.com (140.82.114.3) port 443 (#0)
#6 2.604 * ALPN, offering h2
#6 2.604 * ALPN, offering http/1.1
#6 2.607 * successfully set certificate verify locations:
#6 2.607 *  CAfile: /etc/ssl/certs/ca-certificates.crt
#6 2.607 *  CApath: /etc/ssl/certs
#6 2.607 } [5 bytes data]
#6 2.607 * TLSv1.3 (OUT), TLS handshake, Client hello (1):
#6 2.607 } [512 bytes data]
#6 2.653 * TLSv1.3 (IN), TLS handshake, Server hello (2):
#6 2.653 { [122 bytes data]
#6 2.653 * TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
#6 2.653 { [19 bytes data]
#6 2.653 * TLSv1.3 (IN), TLS handshake, Certificate (11):
#6 2.653 { [2459 bytes data]
#6 2.654 * TLSv1.3 (IN), TLS handshake, CERT verify (15):
#6 2.654 { [78 bytes data]
#6 2.654 * TLSv1.3 (IN), TLS handshake, Finished (20):
#6 2.654 { [36 bytes data]
#6 2.654 * TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
#6 2.654 } [1 bytes data]
#6 2.654 * TLSv1.3 (OUT), TLS handshake, Finished (20):
#6 2.654 } [36 bytes data]
#6 2.654 * SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
#6 2.654 * ALPN, server accepted to use h2
#6 2.654 * Server certificate:
#6 2.654 *  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
#6 2.654 *  start date: Feb 14 00:00:00 2023 GMT
#6 2.654 *  expire date: Mar 14 23:59:59 2024 GMT
#6 2.654 *  subjectAltName: host "github.com" matched cert's "github.com"
#6 2.654 *  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
#6 2.654 *  SSL certificate verify ok.
#6 2.654 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Using HTTP2, server supports multi-use
#6 2.654 * Connection state changed (HTTP/2 confirmed)
#6 2.654 * Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
#6 2.655 } [5 bytes data]
#6 2.655 * Using Stream ID: 1 (easy handle 0xaaaaef12e010)
#6 2.655 } [5 bytes data]
#6 2.655 > GET /NASA-PDS/registry-harvest-service/releases/download/v1.2.0/registry-harvest-service-1.2.0-bin.tar.gz HTTP/2
#6 2.655 > Host: github.com
#6 2.655 > user-agent: curl/7.74.0
#6 2.655 > accept: */*
#6 2.655 > 
#6 2.695 { [5 bytes data]
#6 2.695 * TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
#6 2.695 { [57 bytes data]
#6 2.695 * TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
#6 2.695 { [57 bytes data]
#6 2.695 * old SSL session ID is stale, removing
#6 2.696 { [5 bytes data]
#6 2.696 * Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
#6 2.696 } [5 bytes data]
#6 2.704 < HTTP/2 302 
#6 2.704 < server: GitHub.com
#6 2.704 < date: Tue, 03 Oct 2023 15:22:30 GMT
#6 2.704 < content-type: text/html; charset=utf-8
#6 2.704 < vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
#6 2.704 < location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/412877716/9d35dab0-434d-41a7-833f-4e53161c1473?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231003%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231003T152230Z&X-Amz-Expires=300&X-Amz-Signature=88e5a25b546eb8dc59aa59467a398ed97a84353426e9053d76a4cde5e4bf7b25&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=412877716&response-content-disposition=attachment%3B%20filename%3Dregistry-harvest-service-1.2.0-bin.tar.gz&response-content-type=application%2Foctet-stream
#6 2.704 < cache-control: no-cache
#6 2.704 < strict-transport-security: max-age=31536000; includeSubdomains; preload
#6 2.704 < x-frame-options: deny
#6 2.704 < x-content-type-options: nosniff
#6 2.704 < x-xss-protection: 0
#6 2.704 < referrer-policy: no-referrer-when-downgrade
#6 2.704 < content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.githubcopilot.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events objects-origin.githubusercontent.com *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com support.github.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
#6 2.704 < content-length: 0
#6 2.704 < x-github-request-id: 8ADC:1368:765CF:AF446:651C31D3
#6 2.704 < 
#6 2.704 { [0 bytes data]
#6 2.704 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
#6 2.704 * Connection #0 to host github.com left intact
#6 2.705 * Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/412877716/9d35dab0-434d-41a7-833f-4e53161c1473?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231003%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231003T152230Z&X-Amz-Expires=300&X-Amz-Signature=88e5a25b546eb8dc59aa59467a398ed97a84353426e9053d76a4cde5e4bf7b25&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=412877716&response-content-disposition=attachment%3B%20filename%3Dregistry-harvest-service-1.2.0-bin.tar.gz&response-content-type=application%2Foctet-stream'
#6 2.711 *   Trying 185.199.111.133:443...
#6 2.724 * Connected to objects.githubusercontent.com (185.199.111.133) port 443 (#1)
#6 2.725 * ALPN, offering h2
#6 2.725 * ALPN, offering http/1.1
#6 2.729 * successfully set certificate verify locations:
#6 2.729 *  CAfile: /etc/ssl/certs/ca-certificates.crt
#6 2.729 *  CApath: /etc/ssl/certs
#6 2.729 } [5 bytes data]
#6 2.729 * TLSv1.3 (OUT), TLS handshake, Client hello (1):
#6 2.729 } [512 bytes data]
#6 2.745 * TLSv1.3 (IN), TLS handshake, Server hello (2):
#6 2.745 { [122 bytes data]
#6 2.745 * TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
#6 2.745 { [19 bytes data]
#6 2.746 * TLSv1.3 (IN), TLS handshake, Certificate (11):
#6 2.746 { [3050 bytes data]
#6 2.746 * TLSv1.3 (IN), TLS handshake, CERT verify (15):
#6 2.746 { [264 bytes data]
#6 2.746 * TLSv1.3 (IN), TLS handshake, Finished (20):
#6 2.746 { [52 bytes data]
#6 2.746 * TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
#6 2.746 } [1 bytes data]
#6 2.746 * TLSv1.3 (OUT), TLS handshake, Finished (20):
#6 2.746 } [52 bytes data]
#6 2.747 * SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
#6 2.747 * ALPN, server accepted to use h2
#6 2.747 * Server certificate:
#6 2.747 *  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
#6 2.747 *  start date: Feb 21 00:00:00 2023 GMT
#6 2.747 *  expire date: Mar 20 23:59:59 2024 GMT
#6 2.747 *  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
#6 2.747 *  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
#6 2.747 *  SSL certificate verify ok.
#6 2.747 * Using HTTP2, server supports multi-use
#6 2.747 * Connection state changed (HTTP/2 confirmed)
#6 2.747 * Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
#6 2.747 } [5 bytes data]
#6 2.747 * Using Stream ID: 1 (easy handle 0xaaaaef12e010)
#6 2.747 } [5 bytes data]
#6 2.747 > GET /github-production-release-asset-2e65be/412877716/9d35dab0-434d-41a7-833f-4e53161c1473?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231003%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231003T152230Z&X-Amz-Expires=300&X-Amz-Signature=88e5a25b546eb8dc59aa59467a398ed97a84353426e9053d76a4cde5e4bf7b25&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=412877716&response-content-disposition=attachment%3B%20filename%3Dregistry-harvest-service-1.2.0-bin.tar.gz&response-content-type=application%2Foctet-stream HTTP/2
#6 2.747 > Host: objects.githubusercontent.com
#6 2.747 > user-agent: curl/7.74.0
#6 2.747 > accept: */*
#6 2.747 > 
#6 2.747 { [5 bytes data]
#6 2.747 * TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
#6 2.747 { [209 bytes data]
#6 2.761 * Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
#6 2.761 } [5 bytes data]
#6 2.803 < HTTP/2 200 
#6 2.803 < content-type: application/octet-stream
#6 2.803 < content-md5: 75+AM/hSLVw/mZHtWZuH5A==
#6 2.803 < last-modified: Mon, 02 Oct 2023 19:43:11 GMT
#6 2.803 < etag: "0x8DBC37FCF71B789"
#6 2.803 < server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
#6 2.803 < x-ms-request-id: a6e0dcd3-c01e-0047-150d-f68a0e000000
#6 2.803 < x-ms-version: 2020-04-08
#6 2.803 < x-ms-creation-time: Mon, 02 Oct 2023 19:43:11 GMT
#6 2.803 < x-ms-lease-status: unlocked
#6 2.803 < x-ms-lease-state: available
#6 2.803 < x-ms-blob-type: BlockBlob
#6 2.803 < content-disposition: attachment; filename=registry-harvest-service-1.2.0-bin.tar.gz
#6 2.803 < x-ms-server-encrypted: true
#6 2.803 < via: 1.1 varnish, 1.1 varnish
#6 2.803 < fastly-restarts: 1
#6 2.803 < accept-ranges: bytes
#6 2.803 < age: 28
#6 2.803 < date: Tue, 03 Oct 2023 15:23:00 GMT
#6 2.803 < x-served-by: cache-iad-kcgs7200065-IAD, cache-dfw-kdfw8210105-DFW
#6 2.803 < x-cache: MISS, HIT
#6 2.803 < x-cache-hits: 0, 0
#6 2.803 < x-timer: S1696346580.076324,VS0,VE42
#6 2.803 < content-length: 9259423
#6 2.803 < 
#6 2.803 { [5 bytes data]
#6 3.015 
100 9042k  100 9042k    0     0  19.3M      0 --:--:-- --:--:-- --:--:-- 19.3M
#6 3.015 * Connection #1 to host objects.githubusercontent.com left intact
#6 3.116 Reading package lists...
#6 3.375 Building dependency tree...
#6 3.438 Reading state information...
#6 DONE 3.5s

#7 [3/3] COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
#7 DONE 0.0s

#8 exporting to image
#8 exporting layers 0.0s done
#8 writing image sha256:cd559dbbeb6a3c86f43f8857e798aa24c3de1a32b005970b02aae95a4b9022f2 done
#8 naming to docker.io/nasapds/registry-harvest-service done
#8 DONE 0.0s
```

## ♻️ Related Issues

- #30 maybe? I'm not exacty sure what the issue wants, but this does replace version with a URL

